### PR TITLE
#createInstance "backend" option added.

### DIFF
--- a/sinusbot.class.php
+++ b/sinusbot.class.php
@@ -1677,8 +1677,8 @@ class SinusBot {
   * @param  string  $nickname  Nickname
   * @return array status
   */
-  public function createInstance($nickname = "TS3index.com MusicBot") {
-    return $this->request('/bot/instances', 'POST', json_encode(array("nick" => $nickname)));
+  public function createInstance($nickname = "TS3index.com MusicBot", $backend = "ts3") {
+    return $this->request('/bot/instances', 'POST', json_encode(array("backend" => $backend, "nick" => $nickname)));
   }
   
   


### PR DESCRIPTION
Since SinusBot now allows to also support Discord, we have to specify the appropriate backend on creation of a bot.
Most people would want to use ts3, so I set it as default.

I dont know if the class would work with discord as backend because I dont really know much about VoIP in Discord.