### PR TITLE
Remove "edit bot settings" permission requirement

### DIFF
--- a/src/API.php
+++ b/src/API.php
@@ -409,7 +409,7 @@ class API extends RestClient
     */
     public function getInstanceByUUID($uuid)
     {
-        $instance = $this->request("/bot/i/".$uuid."/settings");
+        $instance = $this->request("/bot/i/".$uuid."/status");
         $instance['uuid'] = $uuid;
         return new Instance($this, $instance);
     }


### PR DESCRIPTION
Allow user to get instance UUID without require further permissions
- The current version requires the user to have access to bot settings, which is exploitable if running a webstream where the auth token is stored in a cookie, which is harmless if the user is only allowed to login without the permissions to modify anything.

This still requires the user to have the login permission.